### PR TITLE
Translated the option menu to spanish

### DIFF
--- a/translations/dde-store.ts
+++ b/translations/dde-store.ts
@@ -40,52 +40,52 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../pages/homepage.cpp" line="50"/>
+        <location filename="../pages/homepage.cpp" line="48"/>
         <source>Messaging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="51"/>
+        <location filename="../pages/homepage.cpp" line="49"/>
         <source>Internet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="52"/>
+        <location filename="../pages/homepage.cpp" line="50"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="53"/>
+        <location filename="../pages/homepage.cpp" line="51"/>
         <source>Development</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="54"/>
+        <location filename="../pages/homepage.cpp" line="52"/>
         <source>Office</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="55"/>
+        <location filename="../pages/homepage.cpp" line="53"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="56"/>
+        <location filename="../pages/homepage.cpp" line="54"/>
         <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="57"/>
+        <location filename="../pages/homepage.cpp" line="55"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="58"/>
+        <location filename="../pages/homepage.cpp" line="56"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="91"/>
+        <location filename="../pages/homepage.cpp" line="89"/>
         <source>View More</source>
         <translation type="unfinished"></translation>
     </message>
@@ -116,82 +116,82 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="30"/>
+        <location filename="../mainwindow.cpp" line="33"/>
         <source>Check for updates</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Check for updates</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="32"/>
+        <location filename="../mainwindow.cpp" line="34"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="115"/>
+        <location filename="../mainwindow.cpp" line="131"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="139"/>
+        <location filename="../mainwindow.cpp" line="158"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="140"/>
+        <location filename="../mainwindow.cpp" line="159"/>
         <source>Messaging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="141"/>
+        <location filename="../mainwindow.cpp" line="160"/>
         <source>Internet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="142"/>
+        <location filename="../mainwindow.cpp" line="161"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="143"/>
+        <location filename="../mainwindow.cpp" line="162"/>
         <source>Development</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="144"/>
+        <location filename="../mainwindow.cpp" line="163"/>
         <source>Office</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="145"/>
+        <location filename="../mainwindow.cpp" line="164"/>
         <source>Graphics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="146"/>
+        <location filename="../mainwindow.cpp" line="165"/>
         <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="147"/>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="148"/>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="149"/>
+        <location filename="../mainwindow.cpp" line="168"/>
         <source>Installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="262"/>
+        <location filename="../mainwindow.cpp" line="294"/>
         <source>Cannot close while app is being installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="263"/>
+        <location filename="../mainwindow.cpp" line="295"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -227,62 +227,62 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../backend/settings.cpp" line="76"/>
+        <location filename="../backend/settings.cpp" line="74"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="77"/>
+        <location filename="../backend/settings.cpp" line="75"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="78"/>
+        <location filename="../backend/settings.cpp" line="76"/>
         <source>Behaviour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="79"/>
+        <location filename="../backend/settings.cpp" line="77"/>
         <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="80"/>
+        <location filename="../backend/settings.cpp" line="78"/>
         <source>Show non-app updates as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="81"/>
+        <location filename="../backend/settings.cpp" line="79"/>
         <source>Max apps per list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="82"/>
+        <location filename="../backend/settings.cpp" line="80"/>
         <source>Minimize to tray on exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="83"/>
+        <location filename="../backend/settings.cpp" line="81"/>
         <source>Check for updates</source>
         <translation type="unfinished">Check for updates</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="84"/>
+        <location filename="../backend/settings.cpp" line="82"/>
         <source>App installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="85"/>
+        <location filename="../backend/settings.cpp" line="83"/>
         <source>App uninstalled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="86"/>
+        <location filename="../backend/settings.cpp" line="84"/>
         <source>Available updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="87"/>
+        <location filename="../backend/settings.cpp" line="85"/>
         <source>Finished updates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -336,22 +336,22 @@
 <context>
     <name>settings</name>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>&quot;System Updates&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>Individual Packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Hourly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-store_ar.ts
+++ b/translations/dde-store_ar.ts
@@ -40,52 +40,52 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../pages/homepage.cpp" line="50"/>
+        <location filename="../pages/homepage.cpp" line="48"/>
         <source>Messaging</source>
         <translation>المراسلة</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="51"/>
+        <location filename="../pages/homepage.cpp" line="49"/>
         <source>Internet</source>
         <translation>الإنترنت</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="52"/>
+        <location filename="../pages/homepage.cpp" line="50"/>
         <source>Games</source>
         <translation>الألعاب</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="53"/>
+        <location filename="../pages/homepage.cpp" line="51"/>
         <source>Development</source>
         <translation>التطوير</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="54"/>
+        <location filename="../pages/homepage.cpp" line="52"/>
         <source>Office</source>
         <translation>المكتب</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="55"/>
+        <location filename="../pages/homepage.cpp" line="53"/>
         <source>Graphics</source>
         <translation>الصور</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="56"/>
+        <location filename="../pages/homepage.cpp" line="54"/>
         <source>Video</source>
         <translation>الفديو</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="57"/>
+        <location filename="../pages/homepage.cpp" line="55"/>
         <source>Music</source>
         <translation>الموسيقى</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="58"/>
+        <location filename="../pages/homepage.cpp" line="56"/>
         <source>System</source>
         <translation>النظام</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="91"/>
+        <location filename="../pages/homepage.cpp" line="89"/>
         <source>View More</source>
         <translation>عرض المزيد</translation>
     </message>
@@ -116,82 +116,82 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="30"/>
+        <location filename="../mainwindow.cpp" line="33"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="32"/>
+        <location filename="../mainwindow.cpp" line="34"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="115"/>
+        <location filename="../mainwindow.cpp" line="131"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="139"/>
+        <location filename="../mainwindow.cpp" line="158"/>
         <source>Home</source>
         <translation>الرئيسية</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="140"/>
+        <location filename="../mainwindow.cpp" line="159"/>
         <source>Messaging</source>
         <translation>المراسلة</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="141"/>
+        <location filename="../mainwindow.cpp" line="160"/>
         <source>Internet</source>
         <translation>الإنترنت</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="142"/>
+        <location filename="../mainwindow.cpp" line="161"/>
         <source>Games</source>
         <translation>الألعاب</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="143"/>
+        <location filename="../mainwindow.cpp" line="162"/>
         <source>Development</source>
         <translation>التطوير</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="144"/>
+        <location filename="../mainwindow.cpp" line="163"/>
         <source>Office</source>
         <translation>المكتب</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="145"/>
+        <location filename="../mainwindow.cpp" line="164"/>
         <source>Graphics</source>
         <translation>الصور</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="146"/>
+        <location filename="../mainwindow.cpp" line="165"/>
         <source>Video</source>
         <translation>الفيديو</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="147"/>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Music</source>
         <translation>الموسيقى</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="148"/>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>System</source>
         <translation>النظام</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="149"/>
+        <location filename="../mainwindow.cpp" line="168"/>
         <source>Installed</source>
         <translation>البرامج المثبتة</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="262"/>
+        <location filename="../mainwindow.cpp" line="294"/>
         <source>Cannot close while app is being installed</source>
         <translation>يتعذر الإغلاق خلال تثبيت البرامج</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="263"/>
+        <location filename="../mainwindow.cpp" line="295"/>
         <source>OK</source>
         <translation>موافق</translation>
     </message>
@@ -227,62 +227,62 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../backend/settings.cpp" line="76"/>
+        <location filename="../backend/settings.cpp" line="74"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="77"/>
+        <location filename="../backend/settings.cpp" line="75"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="78"/>
+        <location filename="../backend/settings.cpp" line="76"/>
         <source>Behaviour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="79"/>
+        <location filename="../backend/settings.cpp" line="77"/>
         <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="80"/>
+        <location filename="../backend/settings.cpp" line="78"/>
         <source>Show non-app updates as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="81"/>
+        <location filename="../backend/settings.cpp" line="79"/>
         <source>Max apps per list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="82"/>
+        <location filename="../backend/settings.cpp" line="80"/>
         <source>Minimize to tray on exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="83"/>
+        <location filename="../backend/settings.cpp" line="81"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="84"/>
+        <location filename="../backend/settings.cpp" line="82"/>
         <source>App installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="85"/>
+        <location filename="../backend/settings.cpp" line="83"/>
         <source>App uninstalled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="86"/>
+        <location filename="../backend/settings.cpp" line="84"/>
         <source>Available updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="87"/>
+        <location filename="../backend/settings.cpp" line="85"/>
         <source>Finished updates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -336,22 +336,22 @@
 <context>
     <name>settings</name>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>&quot;System Updates&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>Individual Packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Hourly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-store_de.ts
+++ b/translations/dde-store_de.ts
@@ -40,52 +40,52 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../pages/homepage.cpp" line="50"/>
+        <location filename="../pages/homepage.cpp" line="48"/>
         <source>Messaging</source>
         <translation>Messaging</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="51"/>
+        <location filename="../pages/homepage.cpp" line="49"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="52"/>
+        <location filename="../pages/homepage.cpp" line="50"/>
         <source>Games</source>
         <translation>Spiele</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="53"/>
+        <location filename="../pages/homepage.cpp" line="51"/>
         <source>Development</source>
         <translation>Entwicklung</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="54"/>
+        <location filename="../pages/homepage.cpp" line="52"/>
         <source>Office</source>
         <translation>Büro</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="55"/>
+        <location filename="../pages/homepage.cpp" line="53"/>
         <source>Graphics</source>
         <translation>Grafik</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="56"/>
+        <location filename="../pages/homepage.cpp" line="54"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="57"/>
+        <location filename="../pages/homepage.cpp" line="55"/>
         <source>Music</source>
         <translation>Musik</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="58"/>
+        <location filename="../pages/homepage.cpp" line="56"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="91"/>
+        <location filename="../pages/homepage.cpp" line="89"/>
         <source>View More</source>
         <translation>Mehr anzeigen</translation>
     </message>
@@ -116,82 +116,82 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="30"/>
+        <location filename="../mainwindow.cpp" line="33"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="32"/>
+        <location filename="../mainwindow.cpp" line="34"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="115"/>
+        <location filename="../mainwindow.cpp" line="131"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="139"/>
+        <location filename="../mainwindow.cpp" line="158"/>
         <source>Home</source>
         <translation>Startseite</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="140"/>
+        <location filename="../mainwindow.cpp" line="159"/>
         <source>Messaging</source>
         <translation>Messaging</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="141"/>
+        <location filename="../mainwindow.cpp" line="160"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="142"/>
+        <location filename="../mainwindow.cpp" line="161"/>
         <source>Games</source>
         <translation>Spiele</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="143"/>
+        <location filename="../mainwindow.cpp" line="162"/>
         <source>Development</source>
         <translation>Entwicklung</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="144"/>
+        <location filename="../mainwindow.cpp" line="163"/>
         <source>Office</source>
         <translation>Büro</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="145"/>
+        <location filename="../mainwindow.cpp" line="164"/>
         <source>Graphics</source>
         <translation>Grafik</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="146"/>
+        <location filename="../mainwindow.cpp" line="165"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="147"/>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Music</source>
         <translation>Musik</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="148"/>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="149"/>
+        <location filename="../mainwindow.cpp" line="168"/>
         <source>Installed</source>
         <translation>Installiert</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="262"/>
+        <location filename="../mainwindow.cpp" line="294"/>
         <source>Cannot close while app is being installed</source>
         <translation>Kann nicht geschlossen werden, während eine App installiert wird</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="263"/>
+        <location filename="../mainwindow.cpp" line="295"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -227,62 +227,62 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../backend/settings.cpp" line="76"/>
+        <location filename="../backend/settings.cpp" line="74"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="77"/>
+        <location filename="../backend/settings.cpp" line="75"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="78"/>
+        <location filename="../backend/settings.cpp" line="76"/>
         <source>Behaviour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="79"/>
+        <location filename="../backend/settings.cpp" line="77"/>
         <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="80"/>
+        <location filename="../backend/settings.cpp" line="78"/>
         <source>Show non-app updates as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="81"/>
+        <location filename="../backend/settings.cpp" line="79"/>
         <source>Max apps per list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="82"/>
+        <location filename="../backend/settings.cpp" line="80"/>
         <source>Minimize to tray on exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="83"/>
+        <location filename="../backend/settings.cpp" line="81"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="84"/>
+        <location filename="../backend/settings.cpp" line="82"/>
         <source>App installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="85"/>
+        <location filename="../backend/settings.cpp" line="83"/>
         <source>App uninstalled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="86"/>
+        <location filename="../backend/settings.cpp" line="84"/>
         <source>Available updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="87"/>
+        <location filename="../backend/settings.cpp" line="85"/>
         <source>Finished updates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -336,22 +336,22 @@
 <context>
     <name>settings</name>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>&quot;System Updates&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>Individual Packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Hourly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/dde-store_en.ts
+++ b/translations/dde-store_en.ts
@@ -40,52 +40,52 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../pages/homepage.cpp" line="50"/>
+        <location filename="../pages/homepage.cpp" line="48"/>
         <source>Messaging</source>
         <translation>Messaging</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="51"/>
+        <location filename="../pages/homepage.cpp" line="49"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="52"/>
+        <location filename="../pages/homepage.cpp" line="50"/>
         <source>Games</source>
         <translation>Games</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="53"/>
+        <location filename="../pages/homepage.cpp" line="51"/>
         <source>Development</source>
         <translation>Development</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="54"/>
+        <location filename="../pages/homepage.cpp" line="52"/>
         <source>Office</source>
         <translation>Office</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="55"/>
+        <location filename="../pages/homepage.cpp" line="53"/>
         <source>Graphics</source>
         <translation>Graphics</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="56"/>
+        <location filename="../pages/homepage.cpp" line="54"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="57"/>
+        <location filename="../pages/homepage.cpp" line="55"/>
         <source>Music</source>
         <translation>Music</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="58"/>
+        <location filename="../pages/homepage.cpp" line="56"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="91"/>
+        <location filename="../pages/homepage.cpp" line="89"/>
         <source>View More</source>
         <translation>View More</translation>
     </message>
@@ -116,82 +116,82 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="30"/>
+        <location filename="../mainwindow.cpp" line="33"/>
         <source>Check for updates</source>
         <translation>Check for updates</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="32"/>
+        <location filename="../mainwindow.cpp" line="34"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="115"/>
+        <location filename="../mainwindow.cpp" line="131"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="139"/>
+        <location filename="../mainwindow.cpp" line="158"/>
         <source>Home</source>
         <translation>Home</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="140"/>
+        <location filename="../mainwindow.cpp" line="159"/>
         <source>Messaging</source>
         <translation>Messaging</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="141"/>
+        <location filename="../mainwindow.cpp" line="160"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="142"/>
+        <location filename="../mainwindow.cpp" line="161"/>
         <source>Games</source>
         <translation>Games</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="143"/>
+        <location filename="../mainwindow.cpp" line="162"/>
         <source>Development</source>
         <translation>Development</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="144"/>
+        <location filename="../mainwindow.cpp" line="163"/>
         <source>Office</source>
         <translation>Office</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="145"/>
+        <location filename="../mainwindow.cpp" line="164"/>
         <source>Graphics</source>
         <translation>Graphics</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="146"/>
+        <location filename="../mainwindow.cpp" line="165"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="147"/>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Music</source>
         <translation>Music</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="148"/>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>System</source>
         <translation>System</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="149"/>
+        <location filename="../mainwindow.cpp" line="168"/>
         <source>Installed</source>
         <translation>Installed</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="262"/>
+        <location filename="../mainwindow.cpp" line="294"/>
         <source>Cannot close while app is being installed</source>
         <translation>Cannot close while app is being installed</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="263"/>
+        <location filename="../mainwindow.cpp" line="295"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -227,62 +227,62 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../backend/settings.cpp" line="76"/>
+        <location filename="../backend/settings.cpp" line="74"/>
         <source>Basic</source>
         <translation>Basic</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="77"/>
+        <location filename="../backend/settings.cpp" line="75"/>
         <source>View</source>
         <translation>View</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="78"/>
+        <location filename="../backend/settings.cpp" line="76"/>
         <source>Behaviour</source>
         <translation>Behaviour</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="79"/>
+        <location filename="../backend/settings.cpp" line="77"/>
         <source>Notifications</source>
         <translation>Notifications</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="80"/>
+        <location filename="../backend/settings.cpp" line="78"/>
         <source>Show non-app updates as</source>
         <translation>Show non-app updates as</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="81"/>
+        <location filename="../backend/settings.cpp" line="79"/>
         <source>Max apps per list</source>
         <translation>Max apps per list</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="82"/>
+        <location filename="../backend/settings.cpp" line="80"/>
         <source>Minimize to tray on exit</source>
         <translation>Minimize to tray on exit</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="83"/>
+        <location filename="../backend/settings.cpp" line="81"/>
         <source>Check for updates</source>
         <translation>Check for updates</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="84"/>
+        <location filename="../backend/settings.cpp" line="82"/>
         <source>App installed</source>
         <translation>App installed</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="85"/>
+        <location filename="../backend/settings.cpp" line="83"/>
         <source>App uninstalled</source>
         <translation>App uninstalled</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="86"/>
+        <location filename="../backend/settings.cpp" line="84"/>
         <source>Available updates</source>
         <translation>Available updates</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="87"/>
+        <location filename="../backend/settings.cpp" line="85"/>
         <source>Finished updates</source>
         <translation>Finished updates</translation>
     </message>
@@ -336,22 +336,22 @@
 <context>
     <name>settings</name>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>&quot;System Updates&quot;</source>
         <translation>&quot;System Updates&quot;</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>Individual Packages</source>
         <translation>Individual Packages</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Hourly</source>
         <translation>Hourly</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Never</source>
         <translation>Never</translation>
     </message>

--- a/translations/dde-store_es.ts
+++ b/translations/dde-store_es.ts
@@ -229,62 +229,62 @@
     <message>
         <location filename="../backend/settings.cpp" line="76"/>
         <source>Basic</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Básico</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="77"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Vista</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="78"/>
         <source>Behaviour</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Comportamiento</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="79"/>
         <source>Notifications</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Notificaciones</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="80"/>
         <source>Show non-app updates as</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mostrar actualizaciones de no-aplicaciones</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="81"/>
         <source>Max apps per list</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Cantidad máxima de apps a mostrar por lista</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="82"/>
         <source>Minimize to tray on exit</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Minimizar a la bandeja del sistema al salir</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="83"/>
         <source>Check for updates</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Buscar actualizaciones</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="84"/>
         <source>App installed</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Aplicaciones instaladas</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="85"/>
         <source>App uninstalled</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Aplicaciones desinstaladas</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="86"/>
         <source>Available updates</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Actualizaciones disponibles</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="87"/>
         <source>Finished updates</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Actualizaciones terminadas</translation>
     </message>
 </context>
 <context>
@@ -338,22 +338,22 @@
     <message>
         <location filename="../backend/settings.cpp" line="30"/>
         <source>&quot;System Updates&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">&quot;Actualizaciones del sistema&quot;</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="30"/>
         <source>Individual Packages</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Paquetes individuales</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="31"/>
         <source>Hourly</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Cada hora</translation>
     </message>
     <message>
         <location filename="../backend/settings.cpp" line="31"/>
         <source>Never</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nunca</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-store_es.ts
+++ b/translations/dde-store_es.ts
@@ -40,52 +40,52 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../pages/homepage.cpp" line="50"/>
+        <location filename="../pages/homepage.cpp" line="48"/>
         <source>Messaging</source>
         <translation>Comunicación</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="51"/>
+        <location filename="../pages/homepage.cpp" line="49"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="52"/>
+        <location filename="../pages/homepage.cpp" line="50"/>
         <source>Games</source>
         <translation>Juegos</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="53"/>
+        <location filename="../pages/homepage.cpp" line="51"/>
         <source>Development</source>
         <translation>Desarrollo</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="54"/>
+        <location filename="../pages/homepage.cpp" line="52"/>
         <source>Office</source>
         <translation>Ofimática</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="55"/>
+        <location filename="../pages/homepage.cpp" line="53"/>
         <source>Graphics</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="56"/>
+        <location filename="../pages/homepage.cpp" line="54"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="57"/>
+        <location filename="../pages/homepage.cpp" line="55"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="58"/>
+        <location filename="../pages/homepage.cpp" line="56"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="91"/>
+        <location filename="../pages/homepage.cpp" line="89"/>
         <source>View More</source>
         <translation>Ver más</translation>
     </message>
@@ -116,82 +116,82 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="30"/>
+        <location filename="../mainwindow.cpp" line="33"/>
         <source>Check for updates</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Buscar actualizaciones</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="32"/>
+        <location filename="../mainwindow.cpp" line="34"/>
         <source>Quit</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Salir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="115"/>
+        <location filename="../mainwindow.cpp" line="131"/>
         <source>Settings</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="139"/>
+        <location filename="../mainwindow.cpp" line="158"/>
         <source>Home</source>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="140"/>
+        <location filename="../mainwindow.cpp" line="159"/>
         <source>Messaging</source>
         <translation>Comunicación</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="141"/>
+        <location filename="../mainwindow.cpp" line="160"/>
         <source>Internet</source>
         <translation>Internet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="142"/>
+        <location filename="../mainwindow.cpp" line="161"/>
         <source>Games</source>
         <translation>Juegos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="143"/>
+        <location filename="../mainwindow.cpp" line="162"/>
         <source>Development</source>
         <translation>Desarrollo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="144"/>
+        <location filename="../mainwindow.cpp" line="163"/>
         <source>Office</source>
         <translation>Ofimática</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="145"/>
+        <location filename="../mainwindow.cpp" line="164"/>
         <source>Graphics</source>
         <translation>Gráficos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="146"/>
+        <location filename="../mainwindow.cpp" line="165"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="147"/>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Music</source>
         <translation>Música</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="148"/>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>System</source>
         <translation>Sistema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="149"/>
+        <location filename="../mainwindow.cpp" line="168"/>
         <source>Installed</source>
         <translation>Instalados</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="262"/>
+        <location filename="../mainwindow.cpp" line="294"/>
         <source>Cannot close while app is being installed</source>
         <translation>No se puede cerrar mientras la aplicacion esta siendo instalada</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="263"/>
+        <location filename="../mainwindow.cpp" line="295"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -227,62 +227,62 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../backend/settings.cpp" line="76"/>
+        <location filename="../backend/settings.cpp" line="74"/>
         <source>Basic</source>
         <translation type="unfinished">Básico</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="77"/>
+        <location filename="../backend/settings.cpp" line="75"/>
         <source>View</source>
         <translation type="unfinished">Vista</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="78"/>
+        <location filename="../backend/settings.cpp" line="76"/>
         <source>Behaviour</source>
         <translation type="unfinished">Comportamiento</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="79"/>
+        <location filename="../backend/settings.cpp" line="77"/>
         <source>Notifications</source>
         <translation type="unfinished">Notificaciones</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="80"/>
+        <location filename="../backend/settings.cpp" line="78"/>
         <source>Show non-app updates as</source>
         <translation type="unfinished">Mostrar actualizaciones de no-aplicaciones</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="81"/>
+        <location filename="../backend/settings.cpp" line="79"/>
         <source>Max apps per list</source>
         <translation type="unfinished">Cantidad máxima de apps a mostrar por lista</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="82"/>
+        <location filename="../backend/settings.cpp" line="80"/>
         <source>Minimize to tray on exit</source>
         <translation type="unfinished">Minimizar a la bandeja del sistema al salir</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="83"/>
+        <location filename="../backend/settings.cpp" line="81"/>
         <source>Check for updates</source>
         <translation type="unfinished">Buscar actualizaciones</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="84"/>
+        <location filename="../backend/settings.cpp" line="82"/>
         <source>App installed</source>
-        <translation type="unfinished">Aplicaciones instaladas</translation>
+        <translation type="unfinished">Aplicación instaladas</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="85"/>
+        <location filename="../backend/settings.cpp" line="83"/>
         <source>App uninstalled</source>
         <translation type="unfinished">Aplicaciones desinstaladas</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="86"/>
+        <location filename="../backend/settings.cpp" line="84"/>
         <source>Available updates</source>
         <translation type="unfinished">Actualizaciones disponibles</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="87"/>
+        <location filename="../backend/settings.cpp" line="85"/>
         <source>Finished updates</source>
         <translation type="unfinished">Actualizaciones terminadas</translation>
     </message>
@@ -336,22 +336,22 @@
 <context>
     <name>settings</name>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>&quot;System Updates&quot;</source>
         <translation type="unfinished">&quot;Actualizaciones del sistema&quot;</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>Individual Packages</source>
         <translation type="unfinished">Paquetes individuales</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Hourly</source>
         <translation type="unfinished">Cada hora</translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Never</source>
         <translation type="unfinished">Nunca</translation>
     </message>

--- a/translations/dde-store_tr.ts
+++ b/translations/dde-store_tr.ts
@@ -40,52 +40,52 @@
 <context>
     <name>HomePage</name>
     <message>
-        <location filename="../pages/homepage.cpp" line="50"/>
+        <location filename="../pages/homepage.cpp" line="48"/>
         <source>Messaging</source>
         <translation>Mesajlaşma</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="51"/>
+        <location filename="../pages/homepage.cpp" line="49"/>
         <source>Internet</source>
         <translation>İnternet</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="52"/>
+        <location filename="../pages/homepage.cpp" line="50"/>
         <source>Games</source>
         <translation>Oyunlar</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="53"/>
+        <location filename="../pages/homepage.cpp" line="51"/>
         <source>Development</source>
         <translation>Geliştirme</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="54"/>
+        <location filename="../pages/homepage.cpp" line="52"/>
         <source>Office</source>
         <translation>Ofis</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="55"/>
+        <location filename="../pages/homepage.cpp" line="53"/>
         <source>Graphics</source>
         <translation>Grafikler</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="56"/>
+        <location filename="../pages/homepage.cpp" line="54"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="57"/>
+        <location filename="../pages/homepage.cpp" line="55"/>
         <source>Music</source>
         <translation>Müzik</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="58"/>
+        <location filename="../pages/homepage.cpp" line="56"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../pages/homepage.cpp" line="91"/>
+        <location filename="../pages/homepage.cpp" line="89"/>
         <source>View More</source>
         <translation>Daha fazla</translation>
     </message>
@@ -116,82 +116,82 @@
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="30"/>
+        <location filename="../mainwindow.cpp" line="33"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="32"/>
+        <location filename="../mainwindow.cpp" line="34"/>
         <source>Quit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="115"/>
+        <location filename="../mainwindow.cpp" line="131"/>
         <source>Settings</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="139"/>
+        <location filename="../mainwindow.cpp" line="158"/>
         <source>Home</source>
         <translation>Ana sayfa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="140"/>
+        <location filename="../mainwindow.cpp" line="159"/>
         <source>Messaging</source>
         <translation>Mesajlaşma</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="141"/>
+        <location filename="../mainwindow.cpp" line="160"/>
         <source>Internet</source>
         <translation>İnternet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="142"/>
+        <location filename="../mainwindow.cpp" line="161"/>
         <source>Games</source>
         <translation>Oyunlar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="143"/>
+        <location filename="../mainwindow.cpp" line="162"/>
         <source>Development</source>
         <translation>Geliştirme</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="144"/>
+        <location filename="../mainwindow.cpp" line="163"/>
         <source>Office</source>
         <translation>Ofis</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="145"/>
+        <location filename="../mainwindow.cpp" line="164"/>
         <source>Graphics</source>
         <translation>Grafikler</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="146"/>
+        <location filename="../mainwindow.cpp" line="165"/>
         <source>Video</source>
         <translation>Video</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="147"/>
+        <location filename="../mainwindow.cpp" line="166"/>
         <source>Music</source>
         <translation>Müzik</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="148"/>
+        <location filename="../mainwindow.cpp" line="167"/>
         <source>System</source>
         <translation>Sistem</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="149"/>
+        <location filename="../mainwindow.cpp" line="168"/>
         <source>Installed</source>
         <translation>Yüklenenler</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="262"/>
+        <location filename="../mainwindow.cpp" line="294"/>
         <source>Cannot close while app is being installed</source>
         <translation>Uygulama yüklenirken kapatılamaz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="263"/>
+        <location filename="../mainwindow.cpp" line="295"/>
         <source>OK</source>
         <translation>Tamam</translation>
     </message>
@@ -227,62 +227,62 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../backend/settings.cpp" line="76"/>
+        <location filename="../backend/settings.cpp" line="74"/>
         <source>Basic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="77"/>
+        <location filename="../backend/settings.cpp" line="75"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="78"/>
+        <location filename="../backend/settings.cpp" line="76"/>
         <source>Behaviour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="79"/>
+        <location filename="../backend/settings.cpp" line="77"/>
         <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="80"/>
+        <location filename="../backend/settings.cpp" line="78"/>
         <source>Show non-app updates as</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="81"/>
+        <location filename="../backend/settings.cpp" line="79"/>
         <source>Max apps per list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="82"/>
+        <location filename="../backend/settings.cpp" line="80"/>
         <source>Minimize to tray on exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="83"/>
+        <location filename="../backend/settings.cpp" line="81"/>
         <source>Check for updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="84"/>
+        <location filename="../backend/settings.cpp" line="82"/>
         <source>App installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="85"/>
+        <location filename="../backend/settings.cpp" line="83"/>
         <source>App uninstalled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="86"/>
+        <location filename="../backend/settings.cpp" line="84"/>
         <source>Available updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="87"/>
+        <location filename="../backend/settings.cpp" line="85"/>
         <source>Finished updates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -336,22 +336,22 @@
 <context>
     <name>settings</name>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>&quot;System Updates&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="30"/>
+        <location filename="../backend/settings.cpp" line="28"/>
         <source>Individual Packages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Hourly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../backend/settings.cpp" line="31"/>
+        <location filename="../backend/settings.cpp" line="29"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
I recommend you to make the option menu window bigger. Because some text lines are large longer in the translation than in the original language.