### PR TITLE
fix: add Build-Depends repair cmake error

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: dekzi <dekzidev@protonmail.com>
 Section: utils
 Priority: optional
 Standards-Version: 4.5.0
-Build-Depends: debhelper (>=9), cmake, qtbase5-dev, libdtkwidget-dev, libdtkcore-dev, libdtkgui-dev, libpackagekitqt5-dev, libappstreamqt-dev, libsnapd-qt-dev, qttools5-dev
+Build-Depends: debhelper (>=9), cmake, qtbase5-dev, libdtkwidget-dev, libdtkcore-dev, libdtkgui-dev, libpackagekitqt5-dev, libappstreamqt-dev, libsnapd-qt-dev, qttools5-dev, pkg-config, cmake-data,
 Homepage: https://github.com/dekzi/dde-store
 
 Package: dde-store


### PR DESCRIPTION
      When building in the debian bullseye environment, it prompts Could NOT find PkgConfig， to add pkg-config, cmake-data build dependencies and resolve