### PR TITLE
fix: blurry banner images on Hi-DPI devices

### DIFF
--- a/widgets/gallery.cpp
+++ b/widgets/gallery.cpp
@@ -99,7 +99,10 @@ void gallery::changeLocalImage(int index)
     currentImage = index;
     pageIndicator->setCurrentPage(index);
 
-    imageView->setPixmap(QPixmap::fromImage(QImage(banners[index].first)).scaled(imageView->width(), imageView->width() * 9/16, Qt::KeepAspectRatio, Qt::SmoothTransformation));
+    const int width = imageView->width() * devicePixelRatioF();
+    QPixmap && pixmap = QPixmap::fromImage(QImage(banners[index].first)).scaled(width, width * 9/16, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+    pixmap.setDevicePixelRatio(devicePixelRatioF());
+    imageView->setPixmap(pixmap);
 }
 
 void gallery::changeImage(int index)


### PR DESCRIPTION
After this patch, the banner gallery widget will no longer be blurry on Hi-DPI devices.