### PR TITLE
fix: check the uninstallation is actually succeed

### DIFF
--- a/backend/sources/packagekit/packagekitsource.cpp
+++ b/backend/sources/packagekit/packagekitsource.cpp
@@ -172,10 +172,15 @@ void PackageKitSource::uninstall(App *app)
                 emit(percentageChanged(app, transaction->percentage()));
         });
 
-        connect(transaction, &Transaction::finished, this, [ = ] {
-            app->state = App::NotInstalled;
-            emit(stateChanged(app));
-            emit(uninstallFinished(app));
+        connect(transaction, &Transaction::finished, this, [ = ](PackageKit::Transaction::Exit status, uint) {
+            if (status == Transaction::ExitSuccess) {
+                app->state = App::NotInstalled;
+                emit(stateChanged(app));
+                emit(uninstallFinished(app));
+            } else {
+                app->state = App::Installed;
+                emit(stateChanged(app));
+            }
             preventingClose = false;
         });
     });


### PR DESCRIPTION
Before the patch:

If user canceled the polkit auth dialog after pressed the uninstall button, the app will still be marked as uninstalled on the UI but it's actually not been uninstalled.

After the patch:

Won't mark it as uninstalled, user can click the uninstall button again to try uninstall again.