### PR TITLE
chore: support AppStreamQt 1.0

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update packages
         run: pacman -Syu --noconfirm
       - name: Install build dependencies
-        run: pacman -S --noconfirm base-devel cmake ninja qt5-base qt5-tools dtkwidget appstream-qt packagekit-qt5
+        run: pacman -S --noconfirm base-devel cmake ninja qt5-base qt5-tools dtkwidget appstream-qt5 packagekit-qt5
       - name: CMake and Make
         run: |
           mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,14 @@ find_package(PkgConfig REQUIRED)
 find_package(Qt5 REQUIRED Core Widgets Network DBus Gui LinguistTools)
 find_package(Dtk REQUIRED Widget Gui)
 find_package(PackageKitQt5 REQUIRED)
-find_package(AppStreamQt REQUIRED)
+find_package(AppStreamQt5 1.0 REQUIRED)
 find_package(PkgConfig REQUIRED)
 include(FindPkgConfig)
 include(GNUInstallDirs)
 
 include_directories(
     ${PackageKitQt5_INCLUDE_DIR}
-    ${AppStreamQt_INCLUDE_DIRS}
+    ${AppStreamQt5_INCLUDE_DIRS}
 )
 
 file(GLOB TS_FILES ./translations/*.ts)
@@ -63,7 +63,7 @@ add_executable(${PROJECT_NAME}
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     ${PackageKitQt5_INCLUDE_DIR}
-    ${AppStreamQt_INCLUDE_DIRS}
+    ${AppStreamQt5_INCLUDE_DIRS}
 )
 
 target_link_libraries(${PROJECT_NAME}
@@ -73,7 +73,7 @@ target_link_libraries(${PROJECT_NAME}
     ${Qt5Widgets_LIBRARIES}
     ${Qt5Network_LIBRARIES}
     ${PackageKitQt5_LIBRARIES}
-    AppStreamQt
+    AppStreamQt5
 )
 
 add_subdirectory(backend/sources)

--- a/backend/sources/packagekit/packagekitsource.cpp
+++ b/backend/sources/packagekit/packagekitsource.cpp
@@ -2,22 +2,23 @@
 #include "backend/settings.h"
 #include "backend/ratingshelper.h"
 #include <Details>
-#include <AppStreamQt/pool.h>
-#include <AppStreamQt/icon.h>
-#include <AppStreamQt/screenshot.h>
-#include <AppStreamQt/image.h>
+#include <AppStreamQt5/pool.h>
+#include <AppStreamQt5/icon.h>
+#include <AppStreamQt5/screenshot.h>
+#include <AppStreamQt5/image.h>
+#include <AppStreamQt5/developer.h>
 
 using namespace PackageKit;
 using namespace AppStream;
 
 PackageKitSource::PackageKitSource()
 {
-    Pool *pool = new Pool;
-    if (!pool->load())
-        Source::error(tr("ERROR: Unable to open AppStream metadata pool") + " - " + pool->lastError());
+    AppStream::Pool pool;
+    if (!pool.load())
+        Source::error(tr("ERROR: Unable to open AppStream metadata pool") + " - " + pool.lastError());
 
-    for (Component app : pool->componentsByKind(AppStream::Component::KindDesktopApp)) {
-        for (QString pkgName : app.packageNames()) {
+    for (const Component & app : pool.componentsByKind(AppStream::Component::KindDesktopApp)) {
+        for (const QString & pkgName : app.packageNames()) {
             metadata.insert(pkgName, app);
         }
     }
@@ -103,10 +104,10 @@ void PackageKitSource::getFullData(App *app)
     if (metadata.contains(app->package)) {
         const Component data = metadata.value(app->package);
 
-        app->developer = data.developerName();
+        app->developer = data.developer().name();
         app->description = data.description();
         
-        for (Screenshot screenshot : data.screenshots()) {
+        for (Screenshot screenshot : data.screenshotsAll()) {
             for (Image image : screenshot.images()) {
                 if (image.kind() == Image::KindSource)
                     app->screenshots << image.url();

--- a/backend/sources/packagekit/packagekitsource.h
+++ b/backend/sources/packagekit/packagekitsource.h
@@ -3,7 +3,7 @@
 
 #include "backend/sourcemanager.h"
 #include <Daemon>
-#include <AppStreamQt/component.h>
+#include <AppStreamQt5/component.h>
 
 class PackageKitSource : public Source
 {


### PR DESCRIPTION
AppStreamQt changes a little bit of its API. This patch follow up the related changes.

Note: Currently Debian's appstream 1.0 package is in its experimental repo, and this won't build with the 0.x version of AppStream package.